### PR TITLE
get new line between testcases

### DIFF
--- a/v2/atcoder-easy-test.user.js
+++ b/v2/atcoder-easy-test.user.js
@@ -1329,9 +1329,15 @@ async function init$3() {
                 const anchors = eSampleTest.querySelectorAll(".input .title .input-output-copier");
                 const count = Math.min(inputs.length, outputs.length, anchors.length);
                 for (let i = 0; i < count; i++) {
+                    const innerDivs = inputs[i].getElementsByTagName("div")
+                    const inputTextArray = []
+                    for (let j = 0; j < innerDivs.length; j++) {
+                        inputTextArray.push(innerDivs[j].textContent)
+                    }
+                    const inputText = inputTextArray.join("\n")
                     testcases.push({
                         title: `Sample ${num++}`,
-                        input: inputs[i].textContent,
+                        input: inputText,
                         output: outputs[i].textContent,
                         anchor: anchors[i],
                     });


### PR DESCRIPTION
[このブログ](https://codeforces.com/blog/entry/105779) で書かれている変更によって、テストケース間の改行が取得されずサンプルの実行が正しく動作しないようになっていたので修正してみました。行ごとに別divになっているようなので、それぞれtextContentを取得してjoin("\n")で結合しています。