### PR TITLE
誤差許容設定を保存できるようにした

### DIFF
--- a/v2/atcoder-easy-test.user.js
+++ b/v2/atcoder-easy-test.user.js
@@ -2108,6 +2108,8 @@ var hTestAllSamples = "<button type=\"button\" id=\"atcoder-easy-test-btn-test-a
         const eRun = E("run");
         const eSetting = E("setting");
         const eVersion = E("version");
+        let savedCheckboxValue = localStorage.getItem("allowableErrorCheckedState");
+        eAllowableErrorCheck.checked = (savedCheckboxValue === 'true');
         eVersion.textContent = atCoderEasyTest.version.current;
         events.on("enable", () => {
             eRun.classList.remove("disabled");
@@ -2185,6 +2187,7 @@ var hTestAllSamples = "<button type=\"button\" id=\"atcoder-easy-test-btn-test-a
             eAllowableError.disabled = !eAllowableErrorCheck.checked;
             eAllowableErrorCheck.addEventListener("change", event => {
                 eAllowableError.disabled = !eAllowableErrorCheck.checked;
+                localStorage.setItem("allowableErrorCheckedState", String(eAllowableErrorCheck.checked));
             });
         }
         // テスト実行

--- a/v2/src/index.ts
+++ b/v2/src/index.ts
@@ -94,6 +94,9 @@ const atCoderEasyTest = {
   const eSetting = E<HTMLAnchorElement>("setting");
   const eVersion = E<HTMLSpanElement>("version");
 
+  let savedCheckboxValue: string | null = localStorage.getItem("allowableErrorCheckedState");
+  eAllowableErrorCheck.checked = (savedCheckboxValue === 'true');
+    
   eVersion.textContent = atCoderEasyTest.version.current;
 
   events.on("enable", () => {
@@ -176,6 +179,7 @@ const atCoderEasyTest = {
     eAllowableError.disabled = !eAllowableErrorCheck.checked;
     eAllowableErrorCheck.addEventListener("change", event => {
       eAllowableError.disabled = !eAllowableErrorCheck.checked;
+      localStorage.setItem("allowableErrorCheckedState", String(eAllowableErrorCheck.checked));
     });
   }
 


### PR DESCRIPTION
許容する小数点誤差の有無の設定を保存できるようにしました。
デフォルトだと許容ありに設定されており、期待された出力が「7」のとき「7.0」を出力しても、atcoder-easy-testはACとなります。しかし、AtcoderではWAとなります。許容しないに設定すると正しく動くのですが、毎回設定を変更するのは面倒であるため、設定内容を保存できるようにしました。