### PR TITLE
Wandboxで使っているGCC 10.2.0をGCC 10.5.0に更新する

### DIFF
--- a/v2/atcoder-easy-test.user.js
+++ b/v2/atcoder-easy-test.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        AtCoder Easy Test v2
 // @namespace   https://atcoder.jp/
-// @version     2.11.11
+// @version     2.11.12
 // @description Make testing sample cases easy
 // @author      magurofly
 // @license     MIT
@@ -1637,7 +1637,7 @@ site.catch(() => {
 const runners = {
     "C GCC 9.3.0 Wandbox": new WandboxRunner("gcc-9.3.0-c", "C (GCC 9.3.0)", { "compiler-option-raw": "-march=native\n-std=gnu11\n-O2\n-DONLINE_JUDGE\n-lm" }),
     "C C17 Clang paiza.io": new PaizaIORunner("c", "C (C17 / Clang)"),
-    "C++ GCC 10.2.0 + Boost 1.73.0 + ACL Wandbox": new WandboxCppRunner("gcc-10.2.0", "C++ (GCC 10.2.0) + ACL", { "compiler-option-raw": "-march=native\n-std=gnu++17\n-Wall\n-Wextra\n-O2\n-DONLINE_JUDGE\n-I/opt/wandbox/boost-1.75.0-gcc-10.2.0/include\n-I." }),
+    "C++ GCC 10.2.0 + Boost 1.73.0 + ACL Wandbox": new WandboxCppRunner("gcc-10.5.0", "C++ (GCC 10.5.0) + ACL", { "compiler-option-raw": "-march=native\n-std=gnu++17\n-Wall\n-Wextra\n-O2\n-DONLINE_JUDGE\n-I/opt/wandbox/boost-1.75.0-gcc-10.5.0/include\n-I." }),
     "C++ GCC 9.3.0 + Boost 1.73.0 + ACL Wandbox": new WandboxCppRunner("gcc-9.3.0", "C++ (GCC 9.3.0) + ACL", { "compiler-option-raw": "-march=native\n-std=gnu++17\n-Wall\n-Wextra\n-O2\n-DONLINE_JUDGE\n-I/opt/wandbox/boost-1.75.0-gcc-9.3.0/include\n-I." }),
     "C++ Clang 10.0.1 + ACL Wandbox": new WandboxCppRunner("clang-10.0.1", "C++ (Clang 10.0.1) + ACL", { "compiler-option-raw": "-march=native\n-std=c++17\n-stdlib=libc++\n-Wall\n-O2\n-DNDEBUG\n-DONLINE_JUDGE\n-I/opt/wandbox/boost-1.75.0-clang-10.0.1/include\n-I." }),
     "Python3 CPython paiza.io": new PaizaIORunner("python3", "Python3"),
@@ -1967,11 +1967,11 @@ const resultList = {
 };
 
 const version = {
-    currentProperty: new ObservableValue("2.11.11"),
+    currentProperty: new ObservableValue("2.11.12"),
     get current() {
         return this.currentProperty.value;
     },
-    latestProperty: new ObservableValue(config.get("version.latest", "2.11.11")),
+    latestProperty: new ObservableValue(config.get("version.latest", "2.11.12")),
     get latest() {
         return this.latestProperty.value;
     },

--- a/v2/package.json
+++ b/v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atcoder-easy-test",
-  "version": "2.11.11",
+  "version": "2.11.12",
   "description": "Make testing sample cases easy",
   "main": "index.js",
   "repository": "https://github.com/magurofly/atcoder-easy-test.git",

--- a/v2/src/codeRunner/index.ts
+++ b/v2/src/codeRunner/index.ts
@@ -17,7 +17,7 @@ import config from "../config";
 const runners: { [runnerId: string]: CodeRunner } = {
   "C GCC 9.3.0 Wandbox": new WandboxRunner("gcc-9.3.0-c", "C (GCC 9.3.0)", { "compiler-option-raw": "-march=native\n-std=gnu11\n-O2\n-DONLINE_JUDGE\n-lm" }),
   "C C17 Clang paiza.io": new PaizaIORunner("c", "C (C17 / Clang)"),
-  "C++ GCC 10.2.0 + Boost 1.73.0 + ACL Wandbox": new WandboxCppRunner("gcc-10.2.0", "C++ (GCC 10.2.0) + ACL", { "compiler-option-raw": "-march=native\n-std=gnu++17\n-Wall\n-Wextra\n-O2\n-DONLINE_JUDGE\n-I/opt/wandbox/boost-1.75.0-gcc-10.2.0/include\n-I." }),
+  "C++ GCC 10.2.0 + Boost 1.73.0 + ACL Wandbox": new WandboxCppRunner("gcc-10.5.0", "C++ (GCC 10.5.0) + ACL", { "compiler-option-raw": "-march=native\n-std=gnu++17\n-Wall\n-Wextra\n-O2\n-DONLINE_JUDGE\n-I/opt/wandbox/boost-1.75.0-gcc-10.5.0/include\n-I." }),
   "C++ GCC 9.3.0 + Boost 1.73.0 + ACL Wandbox": new WandboxCppRunner("gcc-9.3.0", "C++ (GCC 9.3.0) + ACL", { "compiler-option-raw": "-march=native\n-std=gnu++17\n-Wall\n-Wextra\n-O2\n-DONLINE_JUDGE\n-I/opt/wandbox/boost-1.75.0-gcc-9.3.0/include\n-I." }),
   "C++ Clang 10.0.1 + ACL Wandbox": new WandboxCppRunner("clang-10.0.1", "C++ (Clang 10.0.1) + ACL", { "compiler-option-raw": "-march=native\n-std=c++17\n-stdlib=libc++\n-Wall\n-O2\n-DNDEBUG\n-DONLINE_JUDGE\n-I/opt/wandbox/boost-1.75.0-clang-10.0.1/include\n-I." }),
   "Python3 CPython paiza.io": new PaizaIORunner("python3", "Python3"),


### PR DESCRIPTION
Wandboxは同じメジャーバージョンでも古いものは削除してしまう事があるようで、`C++ (GCC 10.2.0) + ACL [Wandbox]`で使用しているGCC 10.2.0が使用できなくなっていました。

とりあえず現在使用可能なGCC 10.5.0に更新しましたが、もっと新しいものを追加してもいいかもしれません。

今回は手動で更新しましたが、最新版のコンパイラを利用したい！という場合、Wandboxの更新情報に張り付いて、その度更新する必要がありそうで若干の面倒くさみがあります。

いっそコンパイラ情報の取得を自動化できれば（APIがあるhttps://github.com/melpon/wandbox/blob/master/kennel/API.md#get-apilistjson ）便利だと思いますが、JS/TSの経験があまりなく実装難度がわかりません…（コンパイラはそんなに頻繁にリリースされないので、あまり気にしなくてもいいかも？）。
