### PR TITLE
環境選択を保存できるようにする

### DIFF
--- a/v2/atcoder-easy-test.user.js
+++ b/v2/atcoder-easy-test.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name        AtCoder Easy Test v2
 // @namespace   https://atcoder.jp/
-// @version     2.11.13
+// @version     2.11.14
 // @description Make testing sample cases easy
 // @author      magurofly
 // @license     MIT
@@ -1969,11 +1969,11 @@ const resultList = {
 };
 
 const version = {
-    currentProperty: new ObservableValue("2.11.13"),
+    currentProperty: new ObservableValue("2.11.14"),
     get current() {
         return this.currentProperty.value;
     },
-    latestProperty: new ObservableValue(config.get("version.latest", "2.11.13")),
+    latestProperty: new ObservableValue(config.get("version.latest", "2.11.14")),
     get latest() {
         return this.latestProperty.value;
     },
@@ -2275,12 +2275,18 @@ var hTestAllSamples = "<button type=\"button\" id=\"atcoder-easy-test-btn-test-a
         }
         // 言語選択関係
         {
-            eLanguage.addEventListener("change", async () => {
+            async function onEnvChange() {
                 const langSelection = config.get("langSelection", {});
                 langSelection[site$1.language.value] = eLanguage.value;
                 config.set("langSelection", langSelection);
                 config.save();
-            });
+            }
+            if (unsafeWindow["jQuery"] && unsafeWindow["jQuery"].fn.select2) {
+                unsafeWindow["jQuery"](eLanguage).on("change", onEnvChange);
+            }
+            else {
+                eLanguage.addEventListener("change", onEnvChange);
+            }
             async function setLanguage() {
                 const languageId = site$1.language.value;
                 while (eLanguage.firstChild)

--- a/v2/package.json
+++ b/v2/package.json
@@ -1,6 +1,6 @@
 {
   "name": "atcoder-easy-test",
-  "version": "2.11.13",
+  "version": "2.11.14",
   "description": "Make testing sample cases easy",
   "main": "index.js",
   "repository": "https://github.com/magurofly/atcoder-easy-test.git",

--- a/v2/src/index.ts
+++ b/v2/src/index.ts
@@ -131,12 +131,18 @@ const atCoderEasyTest = {
 
   // 言語選択関係
   {
-    eLanguage.addEventListener("change", async () => {
+    async function onEnvChange() {
       const langSelection = config.get("langSelection", {});
       langSelection[site.language.value] = eLanguage.value;
       config.set("langSelection", langSelection);
       config.save();
-    });
+    }
+    if (unsafeWindow["jQuery"] && unsafeWindow["jQuery"].fn.select2) {
+      unsafeWindow["jQuery"](eLanguage).on("change", onEnvChange);
+    } else {
+      eLanguage.addEventListener("change", onEnvChange);
+    }
+
 
     async function setLanguage() {
       const languageId = site.language.value;


### PR DESCRIPTION
なぜそうなっているかはわからないが、Environmentのプルダウンメニューにselect2が適用され、値を変えたときjQueryのイベントしか発火されない（Vanilla JSのイベントは発火されない）
→`jQuery.fn.select2`があるときは`$(eSelectLang).on("change", () => { ... })`とするようにした。
select2が適用されないようにするのが一番早いと思うが……