### PR TITLE
Fix/local runner optional

### DIFF
--- a/v2/atcoder-easy-test.user.js
+++ b/v2/atcoder-easy-test.user.js
@@ -1662,6 +1662,10 @@ class LocalRunner extends CodeRunner {
     }
     static async update() {
         const apiURL = config.getString("codeRunner.localRunnerURL", "");
+        if (!apiURL) {
+            // 未設定の場合は何もせず即return（例外を投げない）
+            return;
+        }
         if (!pattern.test(apiURL)) {
             throw "LocalRunner: invalid localRunnerURL";
         }

--- a/v2/src/codeRunner/LocalRunner.ts
+++ b/v2/src/codeRunner/LocalRunner.ts
@@ -33,7 +33,11 @@ export default class LocalRunner extends CodeRunner {
 
   static async update() {
     const apiURL = config.getString("codeRunner.localRunnerURL", "");
-    if (!pattern.test(apiURL)) {
+    if (!apiURL) {
+      // 未設定の場合は何もせず即return（例外を投げない）
+      return;
+    }
+     if (!pattern.test(apiURL)) {
       throw "LocalRunner: invalid localRunnerURL";
     }
 


### PR DESCRIPTION
Issue #57 

## 概要

`LocalRunner.update` メソッドの挙動を修正し、`codeRunner.localRunnerURL` が未設定（空文字列）の場合のみ何もせず return するようにしました。不正なURLが設定されている場合は例外を投げるようになります。

## 変更内容

- `LocalRunner.update` で `localRunnerURL` が空文字列のときのみ return し、不正なURLのみ例外を投げるように修正

## 動作確認

- 設定空欄時、他の実行環境にリクエストが投げられること
- `aaa`といった文字列指定時、`LocalRunner: invalid localRunnerURL`がthrowされること
- 有効な文字列`http://...`指定かつそのサーバーとの通信に失敗したとき、`TypeError: Failed to fetch`がthrowされること
  - 自前API環境を持っていないので、そこの動作確認はしていません


